### PR TITLE
Fix compatibility check for python 2/3

### DIFF
--- a/openssh_wrapper.py
+++ b/openssh_wrapper.py
@@ -15,7 +15,7 @@ import subprocess
 
 __all__ = 'SSHConnection SSHResult SSHError b u b_list u_list'.split()
 
-if sys.version[0] == 2:
+if sys.version[0] == '2':
     text = unicode
     bytes = str
 else:  # PY3K


### PR DESCRIPTION
sys.version[0] is a string, so up to now this check always returned false.