### PR TITLE
Maybe fix a unicode encoding issue with python2

### DIFF
--- a/openssh_wrapper.py
+++ b/openssh_wrapper.py
@@ -448,9 +448,9 @@ class SSHResult(object):
     def repr_binary(self):
         """ Build simple unicode representation from all member values. """
         ret = []
-        ret += [b('command: '), self.command, b('\n')]
-        ret += [b('stdout: '), self.stdout, b('\n')]
-        ret += [b('stderr: '), self.stderr, b('\n')]
+        ret += [b('command: '), b(self.command), b('\n')]
+        ret += [b('stdout: '), b(self.stdout), b('\n')]
+        ret += [b('stderr: '), b(self.stderr), b('\n')]
         ret += [b('returncode: '), b(text(self.returncode))]
         return b('').join(ret)
 


### PR DESCRIPTION
With this, I no longer get the following error:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3932:
ordinal not in range(128)
I don't know enough about python unicode to know if this is a proper fix,
though..